### PR TITLE
Add authentication and role-based access control

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -5,7 +5,10 @@ A super simple FastAPI application that allows students to view and sign up for 
 ## Features
 
 - View all available extracurricular activities
-- Sign up for activities
+- Login/logout with token-based authentication
+- Role-based access control (`student`, `leader`, `teacher`, `admin`)
+- Sign up for activities (authenticated users)
+- Unregister participants (leader/teacher/admin)
 
 ## Getting Started
 
@@ -30,7 +33,24 @@ A super simple FastAPI application that allows students to view and sign up for 
 | Method | Endpoint                                                          | Description                                                         |
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
-| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| POST   | `/auth/login`                                                     | Login and return bearer token + user role                          |
+| POST   | `/auth/logout`                                                    | Logout and invalidate current bearer token                          |
+| GET    | `/auth/me`                                                        | Return currently authenticated user and role                        |
+| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity (requires auth)                             |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Remove participant (leader/teacher/admin only)                  |
+
+## Development users
+
+Seed users are stored in `users.json` for local development:
+
+- `student1` / `student123` (`student`)
+- `leader1` / `leader123` (`leader`)
+- `teacher1` / `teacher123` (`teacher`)
+- `admin1` / `admin123` (`admin`)
+
+Use the returned bearer token from `/auth/login` as:
+
+`Authorization: Bearer <access_token>`
 
 ## Data Model
 

--- a/src/app.py
+++ b/src/app.py
@@ -5,11 +5,15 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends, Header
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
 import os
+import json
+import secrets
 from pathlib import Path
+from typing import Optional
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -18,6 +22,13 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+users_path = current_dir / "users.json"
+with users_path.open("r", encoding="utf-8") as users_file:
+    users_data = json.load(users_file)
+
+users = {user["username"]: user for user in users_data["users"]}
+active_tokens: dict[str, str] = {}
 
 # In-memory activity database
 activities = {
@@ -78,6 +89,40 @@ activities = {
 }
 
 
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+def _extract_token(authorization: Optional[str]) -> str:
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Missing or invalid authorization header")
+    return authorization.replace("Bearer ", "", 1).strip()
+
+
+def get_current_user(authorization: Optional[str] = Header(default=None)):
+    token = _extract_token(authorization)
+    username = active_tokens.get(token)
+
+    if not username or username not in users:
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+
+    user = users[username]
+    return {
+        "username": user["username"],
+        "email": user["email"],
+        "role": user["role"]
+    }
+
+
+def require_roles(*roles: str):
+    def role_guard(current_user=Depends(get_current_user)):
+        if current_user["role"] not in roles:
+            raise HTTPException(status_code=403, detail="Insufficient permissions")
+        return current_user
+    return role_guard
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
@@ -88,9 +133,44 @@ def get_activities():
     return activities
 
 
+@app.post("/auth/login")
+def login(credentials: LoginRequest):
+    user = users.get(credentials.username)
+    if not user or user["password"] != credentials.password:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    token = secrets.token_urlsafe(24)
+    active_tokens[token] = user["username"]
+
+    return {
+        "access_token": token,
+        "token_type": "bearer",
+        "user": {
+            "username": user["username"],
+            "email": user["email"],
+            "role": user["role"]
+        }
+    }
+
+
+@app.post("/auth/logout")
+def logout(authorization: Optional[str] = Header(default=None), current_user=Depends(get_current_user)):
+    token = _extract_token(authorization)
+    active_tokens.pop(token, None)
+    return {"message": f"Logged out {current_user['username']}"}
+
+
+@app.get("/auth/me")
+def me(current_user=Depends(get_current_user)):
+    return {"user": current_user}
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str, current_user=Depends(get_current_user)):
     """Sign up a student for an activity"""
+    if current_user["role"] == "student" and email != current_user["email"]:
+        raise HTTPException(status_code=403, detail="Students can only sign up themselves")
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -107,11 +187,21 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Add student
     activity["participants"].append(email)
-    return {"message": f"Signed up {email} for {activity_name}"}
+    return {
+        "message": f"Signed up {email} for {activity_name}",
+        "performed_by": {
+            "username": current_user["username"],
+            "role": current_user["role"]
+        }
+    }
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(
+    activity_name: str,
+    email: str,
+    current_user=Depends(require_roles("teacher", "admin", "leader"))
+):
     """Unregister a student from an activity"""
     # Validate activity exists
     if activity_name not in activities:
@@ -129,4 +219,10 @@ def unregister_from_activity(activity_name: str, email: str):
 
     # Remove student
     activity["participants"].remove(email)
-    return {"message": f"Unregistered {email} from {activity_name}"}
+    return {
+        "message": f"Unregistered {email} from {activity_name}",
+        "performed_by": {
+            "username": current_user["username"],
+            "role": current_user["role"]
+        }
+    }

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,84 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const loginForm = document.getElementById("login-form");
+  const authInfo = document.getElementById("auth-info");
+  const currentUserLabel = document.getElementById("current-user");
+  const logoutButton = document.getElementById("logout-btn");
+  const emailInput = document.getElementById("email");
+
+  const authState = {
+    token: localStorage.getItem("auth_token") || null,
+    user: null,
+  };
+
+  function authHeaders() {
+    if (!authState.token) {
+      return {};
+    }
+
+    return {
+      Authorization: `Bearer ${authState.token}`,
+    };
+  }
+
+  function canManageParticipants() {
+    return ["teacher", "admin", "leader"].includes(authState.user?.role);
+  }
+
+  function updateAuthUI() {
+    if (authState.user) {
+      loginForm.classList.add("hidden");
+      authInfo.classList.remove("hidden");
+      currentUserLabel.textContent = `${authState.user.username} (${authState.user.role})`;
+
+      signupForm.querySelector("button[type='submit']").disabled = false;
+      activitySelect.disabled = false;
+      emailInput.disabled = false;
+
+      if (authState.user.role === "student") {
+        emailInput.value = authState.user.email;
+        emailInput.disabled = true;
+      }
+    } else {
+      loginForm.classList.remove("hidden");
+      authInfo.classList.add("hidden");
+      currentUserLabel.textContent = "";
+      signupForm.querySelector("button[type='submit']").disabled = true;
+      activitySelect.disabled = true;
+      emailInput.disabled = true;
+      emailInput.value = "";
+    }
+  }
+
+  async function loadCurrentUser() {
+    if (!authState.token) {
+      authState.user = null;
+      updateAuthUI();
+      return;
+    }
+
+    try {
+      const response = await fetch("/auth/me", {
+        headers: {
+          ...authHeaders(),
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error("Session expired");
+      }
+
+      const result = await response.json();
+      authState.user = result.user;
+      updateAuthUI();
+    } catch (error) {
+      authState.token = null;
+      authState.user = null;
+      localStorage.removeItem("auth_token");
+      updateAuthUI();
+    }
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -30,7 +108,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${
+                        canManageParticipants()
+                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                          : ""
+                      }</li>`
                   )
                   .join("")}
               </ul>
@@ -57,9 +139,11 @@ document.addEventListener("DOMContentLoaded", () => {
       });
 
       // Add event listeners to delete buttons
-      document.querySelectorAll(".delete-btn").forEach((button) => {
-        button.addEventListener("click", handleUnregister);
-      });
+      if (canManageParticipants()) {
+        document.querySelectorAll(".delete-btn").forEach((button) => {
+          button.addEventListener("click", handleUnregister);
+        });
+      }
     } catch (error) {
       activitiesList.innerHTML =
         "<p>Failed to load activities. Please try again later.</p>";
@@ -69,6 +153,13 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Handle unregister functionality
   async function handleUnregister(event) {
+    if (!authState.user) {
+      messageDiv.textContent = "Please login first.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      return;
+    }
+
     const button = event.target;
     const activity = button.getAttribute("data-activity");
     const email = button.getAttribute("data-email");
@@ -80,6 +171,9 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: {
+            ...authHeaders(),
+          },
         }
       );
 
@@ -114,6 +208,13 @@ document.addEventListener("DOMContentLoaded", () => {
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
 
+    if (!authState.user) {
+      messageDiv.textContent = "Please login before signing up students.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      return;
+    }
+
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
 
@@ -124,6 +225,9 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: {
+            ...authHeaders(),
+          },
         }
       );
 
@@ -132,7 +236,9 @@ document.addEventListener("DOMContentLoaded", () => {
       if (response.ok) {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
-        signupForm.reset();
+        if (authState.user.role !== "student") {
+          signupForm.reset();
+        }
 
         // Refresh activities list to show updated participants
         fetchActivities();
@@ -155,6 +261,73 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const username = document.getElementById("username").value;
+    const password = document.getElementById("password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        messageDiv.textContent = result.detail || "Login failed.";
+        messageDiv.className = "error";
+      } else {
+        authState.token = result.access_token;
+        authState.user = result.user;
+        localStorage.setItem("auth_token", authState.token);
+        updateAuthUI();
+        fetchActivities();
+        loginForm.reset();
+        messageDiv.textContent = `Logged in as ${result.user.username} (${result.user.role}).`;
+        messageDiv.className = "success";
+      }
+
+      messageDiv.classList.remove("hidden");
+      setTimeout(() => {
+        messageDiv.classList.add("hidden");
+      }, 5000);
+    } catch (error) {
+      messageDiv.textContent = "Login failed. Please try again.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+    }
+  });
+
+  logoutButton.addEventListener("click", async () => {
+    try {
+      if (authState.token) {
+        await fetch("/auth/logout", {
+          method: "POST",
+          headers: {
+            ...authHeaders(),
+          },
+        });
+      }
+    } finally {
+      authState.token = null;
+      authState.user = null;
+      localStorage.removeItem("auth_token");
+      updateAuthUI();
+      fetchActivities();
+      messageDiv.textContent = "Logged out.";
+      messageDiv.className = "info";
+      messageDiv.classList.remove("hidden");
+      setTimeout(() => {
+        messageDiv.classList.add("hidden");
+      }, 3000);
+    }
+  });
+
   // Initialize app
-  fetchActivities();
+  loadCurrentUser().then(fetchActivities);
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,6 +10,17 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <div id="auth-panel">
+        <form id="login-form">
+          <input type="text" id="username" placeholder="Username" required />
+          <input type="password" id="password" placeholder="Password" required />
+          <button type="submit">Login</button>
+        </form>
+        <div id="auth-info" class="hidden">
+          <span id="current-user"></span>
+          <button id="logout-btn" type="button">Logout</button>
+        </div>
+      </div>
     </header>
 
     <main>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -28,6 +28,38 @@ header h1 {
   margin-bottom: 10px;
 }
 
+#auth-panel {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  margin-top: 15px;
+  flex-wrap: wrap;
+}
+
+#login-form {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+#login-form input {
+  padding: 8px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+
+#auth-info {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+#current-user {
+  font-weight: bold;
+}
+
 main {
   display: flex;
   flex-wrap: wrap;
@@ -162,6 +194,13 @@ button {
 
 button:hover {
   background-color: #3949ab;
+}
+
+button:disabled,
+select:disabled,
+input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .message {

--- a/src/users.json
+++ b/src/users.json
@@ -1,0 +1,28 @@
+{
+  "users": [
+    {
+      "username": "student1",
+      "password": "student123",
+      "email": "student1@mergington.edu",
+      "role": "student"
+    },
+    {
+      "username": "leader1",
+      "password": "leader123",
+      "email": "leader1@mergington.edu",
+      "role": "leader"
+    },
+    {
+      "username": "teacher1",
+      "password": "teacher123",
+      "email": "teacher1@mergington.edu",
+      "role": "teacher"
+    },
+    {
+      "username": "admin1",
+      "password": "admin123",
+      "email": "admin1@mergington.edu",
+      "role": "admin"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Implements issue #8 by adding authentication and role-based access control across API and UI.

## What changed
- Added token-based auth endpoints:
  - `POST /auth/login`
  - `POST /auth/logout`
  - `GET /auth/me`
- Added seeded local users in `src/users.json` with roles:
  - `student`, `leader`, `teacher`, `admin`
- Protected activity mutations:
  - `signup` now requires authentication
  - students can only sign up themselves
  - `unregister` requires `leader`, `teacher`, or `admin`
- Updated frontend with login/logout panel and role-aware behavior:
  - signup form requires login
  - participant delete controls only visible to privileged roles
- Updated `src/README.md` with endpoints and development credentials

## Verification
Smoke-tested auth and role behavior with FastAPI TestClient:
- unauthenticated signup -> `401`
- student login -> `200`
- student self-signup -> `200`
- student unregister -> `403`
- teacher unregister -> `200`
- `/auth/me` returns role information

## Notes
Credentials are intentionally seed/dev-only for this exercise.